### PR TITLE
feat: Add user-defined folders for organizing conversations

### DIFF
--- a/.agents/plans/completed/user-defined-folders.plan.md
+++ b/.agents/plans/completed/user-defined-folders.plan.md
@@ -1,0 +1,211 @@
+# Plan: User-Defined Folders for Chat Conversations
+
+## Summary
+
+Add user-defined folders to organize chat conversations in the sidebar. Users can create folders, assign conversations to them, and see conversations grouped by folder. All data persists in localStorage (no database changes). Folders are collapsible sections in the sidebar.
+
+## User Story
+
+As a chat user
+I want to create folders and organize my conversations into them
+So that I can keep related chats grouped together
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Type | NEW_CAPABILITY |
+| Complexity | MEDIUM |
+| Systems Affected | Sidebar UI, localStorage hooks |
+| Time Estimate | 15 minutes |
+
+---
+
+## Patterns to Follow
+
+### LocalStorage Hook Pattern
+```typescript
+// SOURCE: src/hooks/use-local-storage.ts:11-59
+export function useLocalStorage(key: string) {
+  const [items, setItems] = useState<LocalStorageItem[]>([]);
+  // ... addItem, removeItem, updateItem callbacks
+  return { items, addItem, removeItem, updateItem };
+}
+```
+
+### Sidebar Component Pattern
+```typescript
+// SOURCE: src/components/chat/chat-sidebar.tsx:28-76
+function SidebarContent({ conversations, ... }) {
+  const sorted = [...conversations].sort(...);
+  return (
+    <div className="flex h-full flex-col">
+      <div className="p-3">
+        <Button>New Chat</Button>
+      </div>
+      <ScrollArea className="flex-1 px-2">
+        {/* conversation list */}
+      </ScrollArea>
+    </div>
+  );
+}
+```
+
+### Dropdown Menu Pattern (for "Move to Folder")
+```typescript
+// SOURCE: src/components/chat/conversation-item.tsx:102-124
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="ghost" size="icon-sm">
+      <MoreHorizontal className="size-3.5" />
+    </Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="end">
+    <DropdownMenuItem onClick={...}>
+      <Pencil className="size-3.5" />
+      Rename
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+---
+
+## Files to Change
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/hooks/use-local-storage.ts` | UPDATE | Add optional `folderId` field to item type |
+| `src/hooks/use-folders.ts` | CREATE | Hook for managing folders in localStorage |
+| `src/components/chat/chat-sidebar.tsx` | UPDATE | Add folder sections, "New Folder" button |
+| `src/components/chat/conversation-item.tsx` | UPDATE | Add "Move to Folder" dropdown menu option |
+
+---
+
+## Tasks
+
+Execute in order. Each task is atomic and verifiable.
+
+### Task 1: Extend LocalStorageItem type
+
+- **File**: `src/hooks/use-local-storage.ts`
+- **Action**: UPDATE
+- **Implement**: Add optional `folderId?: string` to `LocalStorageItem` interface
+- **Mirror**: Same file, line 5-9
+- **Validate**: `bun run lint && npx tsc --noEmit`
+
+### Task 2: Create useFolders hook
+
+- **File**: `src/hooks/use-folders.ts`
+- **Action**: CREATE
+- **Implement**:
+  - Define `Folder` interface: `{ id: string; name: string; createdAt: string }`
+  - Create `useFolders()` hook using same pattern as `useLocalStorage`
+  - Use key `"chat-folders"` for localStorage
+  - Export: `folders`, `addFolder`, `removeFolder`, `renameFolder`
+- **Mirror**: `src/hooks/use-local-storage.ts:1-59` - follow same pattern
+- **Validate**: `bun run lint && npx tsc --noEmit`
+
+### Task 3: Update ChatSidebar with folder UI
+
+- **File**: `src/components/chat/chat-sidebar.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Import `useFolders` hook, `FolderPlus`, `ChevronRight`, `ChevronDown` icons
+  - Add props: `folders`, `onCreateFolder`, `onMoveToFolder`
+  - Add "New Folder" button next to "New Chat"
+  - Group conversations by `folderId`:
+    - Unfiled conversations at top
+    - Each folder as collapsible section with folder name header
+  - Use local state for collapsed/expanded folders
+- **Mirror**: Same file, lines 40-76 for structure
+- **Validate**: `bun run lint && npx tsc --noEmit`
+
+### Task 4: Add "Move to Folder" to ConversationItem
+
+- **File**: `src/components/chat/conversation-item.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add props: `folders: Array<{id: string; name: string}>`, `onMoveToFolder: (convId: string, folderId: string | null) => void`
+  - Add `DropdownMenuSub` with folder list after Rename option
+  - Include "No Folder" option to unfiled
+- **Mirror**: Same file, lines 102-124 for dropdown pattern
+- **Validate**: `bun run lint && npx tsc --noEmit`
+
+### Task 5: Wire up in ChatLayout or parent
+
+- **File**: `src/components/chat/chat-layout.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Import and use `useFolders` hook
+  - Pass folders and handlers to ChatSidebar
+  - Create `handleMoveToFolder` that calls `updateItem(convId, { folderId })`
+  - Create `handleCreateFolder` with prompt/input for folder name
+- **Mirror**: Same file for prop passing pattern
+- **Validate**: `bun run lint && npx tsc --noEmit`
+
+### Task 6: Add inline folder creation UI
+
+- **File**: `src/components/chat/chat-sidebar.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add state for `isCreatingFolder` and `newFolderName`
+  - When "New Folder" clicked, show inline Input (same pattern as rename in ConversationItem)
+  - On Enter/blur, call `onCreateFolder(name)`
+- **Mirror**: `src/components/chat/conversation-item.tsx:75-88` for inline input pattern
+- **Validate**: `bun run lint && npx tsc --noEmit`
+
+---
+
+## Validation
+
+```bash
+# Type check
+npx tsc --noEmit
+
+# Lint
+bun run lint
+
+# Manual test
+bun run dev
+# Then: Create folder, move conversation to it, verify persistence on refresh
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] User can click "New Folder" and type a name to create a folder
+- [ ] Folders appear as collapsible sections in sidebar
+- [ ] User can move conversations to folders via dropdown menu
+- [ ] User can move conversations back to "No Folder"
+- [ ] Folder state persists across page refresh (localStorage)
+- [ ] Type check passes
+- [ ] Lint passes
+
+---
+
+## Quick Implementation Notes
+
+**localStorage keys:**
+- `chat-conversations` - existing, add `folderId` field
+- `chat-folders` - new, stores folder list
+
+**Folder structure in sidebar:**
+```
+[New Chat] [New Folder]
+─────────────────────
+📁 Work (▼ collapse)
+  - Chat about project X
+  - Meeting notes
+📁 Personal (▶ expand)
+─────────────────────
+Unfiled
+  - Random chat
+  - Another chat
+```
+
+**Skip for MVP (add later):**
+- Folder deletion
+- Folder renaming
+- Drag-and-drop reordering

--- a/src/components/chat/chat-layout.tsx
+++ b/src/components/chat/chat-layout.tsx
@@ -5,6 +5,7 @@ import { useCallback, useState } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { useChat } from "@/hooks/use-chat";
+import { useFolders } from "@/hooks/use-folders";
 
 import { ChatHeader } from "./chat-header";
 import { ChatInput } from "./chat-input";
@@ -24,7 +25,10 @@ export function ChatLayout() {
     createNewChat,
     renameConversation,
     deleteConversation,
+    moveToFolder,
   } = useChat();
+
+  const { folders, addFolder } = useFolders();
 
   const [isMobileOpen, setIsMobileOpen] = useState(false);
 
@@ -38,17 +42,27 @@ export function ChatLayout() {
     setIsMobileOpen(false);
   }, []);
 
+  const handleCreateFolder = useCallback(
+    (name: string) => {
+      addFolder(name);
+    },
+    [addFolder],
+  );
+
   const hasMessages = messages.length > 0 || isStreaming;
 
   return (
     <div className="flex h-screen">
       <ChatSidebar
         conversations={conversations}
+        folders={folders}
         activeConversationId={activeConversationId}
         onSelectConversation={selectConversation}
         onNewChat={createNewChat}
         onRenameConversation={renameConversation}
         onDeleteConversation={deleteConversation}
+        onCreateFolder={handleCreateFolder}
+        onMoveToFolder={moveToFolder}
         isMobileOpen={isMobileOpen}
         onMobileClose={closeMobile}
       />

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1,73 +1,217 @@
 "use client";
 
-import { MessageSquare, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, FolderPlus, MessageSquare, Plus } from "lucide-react";
+import type { KeyboardEvent } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
 
 import { ConversationItem } from "./conversation-item";
+
+interface Folder {
+  id: string;
+  name: string;
+}
 
 interface Conversation {
   id: string;
   title: string;
   updatedAt: string;
+  folderId?: string | undefined;
 }
 
 interface ChatSidebarProps {
   conversations: Conversation[];
+  folders: Folder[];
   activeConversationId: string | null;
   onSelectConversation: (id: string) => void;
   onNewChat: () => void;
   onRenameConversation: (id: string, title: string) => void;
   onDeleteConversation: (id: string) => void;
+  onCreateFolder: (name: string) => void;
+  onMoveToFolder: (conversationId: string, folderId: string | null) => void;
   isMobileOpen: boolean;
   onMobileClose: () => void;
 }
 
 function SidebarContent({
   conversations,
+  folders,
   activeConversationId,
   onSelectConversation,
   onNewChat,
   onRenameConversation,
   onDeleteConversation,
+  onCreateFolder,
+  onMoveToFolder,
 }: Omit<ChatSidebarProps, "isMobileOpen" | "onMobileClose">) {
+  const [collapsedFolders, setCollapsedFolders] = useState<Set<string>>(new Set());
+  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const sorted = [...conversations].sort(
     (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
   );
 
+  const unfiledConversations = sorted.filter((c) => !c.folderId);
+  const conversationsByFolder = new Map<string, Conversation[]>();
+  for (const folder of folders) {
+    conversationsByFolder.set(
+      folder.id,
+      sorted.filter((c) => c.folderId === folder.id),
+    );
+  }
+
+  const toggleFolder = useCallback((folderId: string) => {
+    setCollapsedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(folderId)) {
+        next.delete(folderId);
+      } else {
+        next.add(folderId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleStartCreateFolder = useCallback(() => {
+    setIsCreatingFolder(true);
+    setNewFolderName("");
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, []);
+
+  const handleSubmitFolder = useCallback(() => {
+    const trimmed = newFolderName.trim();
+    if (trimmed) {
+      onCreateFolder(trimmed);
+    }
+    setIsCreatingFolder(false);
+    setNewFolderName("");
+  }, [newFolderName, onCreateFolder]);
+
+  const handleFolderKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        handleSubmitFolder();
+      } else if (e.key === "Escape") {
+        setIsCreatingFolder(false);
+        setNewFolderName("");
+      }
+    },
+    [handleSubmitFolder],
+  );
+
+  const renderConversation = (conv: Conversation) => (
+    <ConversationItem
+      key={conv.id}
+      id={conv.id}
+      title={conv.title}
+      isActive={conv.id === activeConversationId}
+      folders={folders}
+      currentFolderId={conv.folderId}
+      onSelect={onSelectConversation}
+      onRename={onRenameConversation}
+      onDelete={onDeleteConversation}
+      onMoveToFolder={onMoveToFolder}
+    />
+  );
+
   return (
     <div className="flex h-full flex-col">
-      <div className="p-3">
+      <div className="flex gap-2 p-3">
         <Button
           variant="outline"
-          className="w-full justify-start gap-2 border-primary/30 hover:bg-primary/10 hover:text-primary"
+          className="flex-1 justify-start gap-2 border-primary/30 hover:bg-primary/10 hover:text-primary"
           onClick={onNewChat}
         >
           <Plus className="size-4" />
           New Chat
         </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          className="border-primary/30 hover:bg-primary/10 hover:text-primary"
+          onClick={handleStartCreateFolder}
+          title="New Folder"
+        >
+          <FolderPlus className="size-4" />
+        </Button>
       </div>
+
       <ScrollArea className="flex-1 px-2">
-        {sorted.length === 0 ? (
+        {isCreatingFolder && (
+          <div className="mb-2 px-2">
+            <Input
+              ref={inputRef}
+              value={newFolderName}
+              onChange={(e) => setNewFolderName(e.target.value)}
+              onBlur={handleSubmitFolder}
+              onKeyDown={handleFolderKeyDown}
+              placeholder="Folder name..."
+              className="h-8 text-sm"
+            />
+          </div>
+        )}
+
+        {folders.length === 0 && sorted.length === 0 ? (
           <div className="text-muted-foreground flex flex-col items-center gap-2 px-4 py-8 text-center text-sm">
             <MessageSquare className="size-8 opacity-50" />
             <p>No conversations yet</p>
           </div>
         ) : (
-          <div className="space-y-0.5">
-            {sorted.map((conv) => (
-              <ConversationItem
-                key={conv.id}
-                id={conv.id}
-                title={conv.title}
-                isActive={conv.id === activeConversationId}
-                onSelect={onSelectConversation}
-                onRename={onRenameConversation}
-                onDelete={onDeleteConversation}
-              />
-            ))}
+          <div className="space-y-1">
+            {/* Folders */}
+            {folders.map((folder) => {
+              const folderConversations = conversationsByFolder.get(folder.id) ?? [];
+              const isCollapsed = collapsedFolders.has(folder.id);
+
+              return (
+                <div key={folder.id}>
+                  <button
+                    type="button"
+                    onClick={() => toggleFolder(folder.id)}
+                    className={cn(
+                      "flex w-full items-center gap-1 rounded-md px-2 py-1.5 text-sm font-medium",
+                      "hover:bg-accent/50 text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {isCollapsed ? (
+                      <ChevronRight className="size-4" />
+                    ) : (
+                      <ChevronDown className="size-4" />
+                    )}
+                    <span className="truncate">{folder.name}</span>
+                    <span className="text-muted-foreground ml-auto text-xs">
+                      {folderConversations.length}
+                    </span>
+                  </button>
+                  {!isCollapsed && (
+                    <div className="ml-2 space-y-0.5 border-l pl-2">
+                      {folderConversations.length === 0 ? (
+                        <p className="text-muted-foreground px-2 py-1 text-xs italic">Empty</p>
+                      ) : (
+                        folderConversations.map(renderConversation)
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Unfiled conversations */}
+            {unfiledConversations.length > 0 && (
+              <div className={cn(folders.length > 0 && "mt-3 border-t pt-3")}>
+                {folders.length > 0 && (
+                  <p className="text-muted-foreground mb-1 px-2 text-xs font-medium">Unfiled</p>
+                )}
+                <div className="space-y-0.5">{unfiledConversations.map(renderConversation)}</div>
+              </div>
+            )}
           </div>
         )}
       </ScrollArea>
@@ -77,11 +221,14 @@ function SidebarContent({
 
 export function ChatSidebar({
   conversations,
+  folders,
   activeConversationId,
   onSelectConversation,
   onNewChat,
   onRenameConversation,
   onDeleteConversation,
+  onCreateFolder,
+  onMoveToFolder,
   isMobileOpen,
   onMobileClose,
 }: ChatSidebarProps) {
@@ -91,11 +238,14 @@ export function ChatSidebar({
       <aside className="bg-sidebar hidden h-full w-72 border-r md:block">
         <SidebarContent
           conversations={conversations}
+          folders={folders}
           activeConversationId={activeConversationId}
           onSelectConversation={onSelectConversation}
           onNewChat={onNewChat}
           onRenameConversation={onRenameConversation}
           onDeleteConversation={onDeleteConversation}
+          onCreateFolder={onCreateFolder}
+          onMoveToFolder={onMoveToFolder}
         />
       </aside>
 
@@ -112,6 +262,7 @@ export function ChatSidebar({
           <SheetTitle className="sr-only">Chat history</SheetTitle>
           <SidebarContent
             conversations={conversations}
+            folders={folders}
             activeConversationId={activeConversationId}
             onSelectConversation={(id) => {
               onSelectConversation(id);
@@ -123,6 +274,8 @@ export function ChatSidebar({
             }}
             onRenameConversation={onRenameConversation}
             onDeleteConversation={onDeleteConversation}
+            onCreateFolder={onCreateFolder}
+            onMoveToFolder={onMoveToFolder}
           />
         </SheetContent>
       </Sheet>

--- a/src/components/chat/conversation-item.tsx
+++ b/src/components/chat/conversation-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Folder, FolderX, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import type { KeyboardEvent } from "react";
 import { useCallback, useRef, useState } from "react";
 
@@ -19,27 +19,42 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
+interface FolderInfo {
+  id: string;
+  name: string;
+}
+
 interface ConversationItemProps {
   id: string;
   title: string;
   isActive: boolean;
+  folders: FolderInfo[];
+  currentFolderId?: string | undefined;
   onSelect: (id: string) => void;
   onRename: (id: string, title: string) => void;
   onDelete: (id: string) => void;
+  onMoveToFolder: (conversationId: string, folderId: string | null) => void;
 }
 
 export function ConversationItem({
   id,
   title,
   isActive,
+  folders,
+  currentFolderId,
   onSelect,
   onRename,
   onDelete,
+  onMoveToFolder,
 }: ConversationItemProps) {
   const [isRenaming, setIsRenaming] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
@@ -116,6 +131,34 @@ export function ConversationItem({
             <Pencil className="size-3.5" />
             Rename
           </DropdownMenuItem>
+          {folders.length > 0 && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <Folder className="size-3.5" />
+                Move to folder
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {currentFolderId && (
+                  <DropdownMenuItem onClick={() => onMoveToFolder(id, null)}>
+                    <FolderX className="size-3.5" />
+                    Remove from folder
+                  </DropdownMenuItem>
+                )}
+                {currentFolderId && folders.length > 0 && <DropdownMenuSeparator />}
+                {folders.map((folder) => (
+                  <DropdownMenuItem
+                    key={folder.id}
+                    onClick={() => onMoveToFolder(id, folder.id)}
+                    disabled={folder.id === currentFolderId}
+                  >
+                    <Folder className="size-3.5" />
+                    {folder.name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
+          <DropdownMenuSeparator />
           <DropdownMenuItem variant="destructive" onClick={() => setIsDeleteOpen(true)}>
             <Trash2 className="size-3.5" />
             Delete

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -240,6 +240,13 @@ export function useChat() {
     [activeConversationId, removeItem],
   );
 
+  const moveToFolder = useCallback(
+    (conversationId: string, folderId: string | null) => {
+      updateItem(conversationId, { folderId: folderId ?? undefined });
+    },
+    [updateItem],
+  );
+
   return {
     conversations,
     activeConversationId,
@@ -252,5 +259,6 @@ export function useChat() {
     createNewChat,
     renameConversation,
     deleteConversation,
+    moveToFolder,
   };
 }

--- a/src/hooks/use-folders.ts
+++ b/src/hooks/use-folders.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface Folder {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+const STORAGE_KEY = "chat-folders";
+
+export function useFolders() {
+  const [folders, setFolders] = useState<Folder[]>([]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setFolders(JSON.parse(stored) as Folder[]);
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }, []);
+
+  const addFolder = useCallback((name: string) => {
+    const folder: Folder = {
+      id: crypto.randomUUID(),
+      name,
+      createdAt: new Date().toISOString(),
+    };
+    setFolders((prev) => {
+      const next = [...prev, folder];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+    return folder;
+  }, []);
+
+  const removeFolder = useCallback((id: string) => {
+    setFolders((prev) => {
+      const next = prev.filter((f) => f.id !== id);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  const renameFolder = useCallback((id: string, name: string) => {
+    setFolders((prev) => {
+      const next = prev.map((f) => (f.id === id ? { ...f, name } : f));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  return { folders, addFolder, removeFolder, renameFolder };
+}

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -6,6 +6,7 @@ interface LocalStorageItem {
   id: string;
   title: string;
   updatedAt: string;
+  folderId?: string | undefined;
 }
 
 export function useLocalStorage(key: string) {


### PR DESCRIPTION
Users can now create custom folders to organize their chat conversations:
- New Folder button in sidebar to create folders
- Collapsible folder sections with conversation counts
- Move conversations to folders via dropdown menu
- Remove from folder option to move back to Unfiled
- All data persists in localStorage