### PR TITLE
Add character count indicator to chat input

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -74,9 +74,9 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
           <Send className="size-4" />
         </Button>
       </div>
-      <div className="mx-auto mt-1.5 flex max-w-3xl justify-between">
+      <div className="mx-auto mt-1.5 flex max-w-3xl items-center justify-between">
         <p className="text-muted-foreground/50 text-xs">Enter to send · Shift+Enter for new line</p>
-        <p className={`text-xs ${charCountClass}`} aria-live="polite">
+        <p className={`text-xs ${charCountClass}`} aria-live="polite" aria-label="Character count">
           {charCount} / {MAX_CHARS}
         </p>
       </div>

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -7,6 +7,9 @@ import { useCallback, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 
+const MAX_CHARS = 4000;
+const WARN_CHARS = 3800;
+
 interface ChatInputProps {
   onSend: (content: string) => void;
   disabled: boolean;
@@ -16,9 +19,19 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const charCount = value.length;
+  const isOverLimit = charCount > MAX_CHARS;
+  const isNearLimit = charCount > WARN_CHARS;
+
+  const charCountClass = isOverLimit
+    ? "text-red-500"
+    : isNearLimit
+      ? "text-amber-500"
+      : "text-muted-foreground/50";
+
   const handleSend = useCallback(() => {
     const trimmed = value.trim();
-    if (!trimmed || disabled) {
+    if (!trimmed || disabled || isOverLimit) {
       return;
     }
     onSend(trimmed);
@@ -26,7 +39,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
-  }, [value, disabled, onSend]);
+  }, [value, disabled, isOverLimit, onSend]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -53,7 +66,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
         />
         <Button
           onClick={handleSend}
-          disabled={disabled || !value.trim()}
+          disabled={disabled || !value.trim() || isOverLimit}
           size="icon"
           className="send-button-glow shrink-0"
           aria-label="Send message"
@@ -61,9 +74,12 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
           <Send className="size-4" />
         </Button>
       </div>
-      <p className="text-muted-foreground/50 mt-1.5 text-center text-xs">
-        Enter to send · Shift+Enter for new line
-      </p>
+      <div className="mx-auto mt-1.5 flex max-w-3xl justify-between">
+        <p className="text-muted-foreground/50 text-xs">Enter to send · Shift+Enter for new line</p>
+        <p className={`text-xs ${charCountClass}`} aria-live="polite">
+          {charCount} / {MAX_CHARS}
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/chat/tests/chat-input.test.tsx
+++ b/src/components/chat/tests/chat-input.test.tsx
@@ -65,4 +65,23 @@ describe("ChatInput", () => {
 
     expect(onSend).not.toHaveBeenCalled();
   });
+
+  it("shows character count indicator", async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={() => {}} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText("Type a message...");
+    await user.type(textarea, "Hello");
+
+    expect(screen.getByText("5 / 4000")).toBeInTheDocument();
+  });
+
+  it("disables send button when over 4000 character limit", async () => {
+    render(<ChatInput onSend={() => {}} disabled={false} />);
+
+    // Simulate a value over the limit by checking the component behavior
+    // We test the over-limit state by checking the counter displays correctly at 0
+    expect(screen.getByText("0 / 4000")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+  });
 });

--- a/src/components/chat/tests/chat-input.test.tsx
+++ b/src/components/chat/tests/chat-input.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ChatInput } from "../chat-input";
@@ -66,22 +66,42 @@ describe("ChatInput", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("shows character count indicator", async () => {
+  it("shows character count indicator", () => {
+    render(<ChatInput onSend={() => {}} disabled={false} />);
+    expect(screen.getByLabelText("Character count")).toBeInTheDocument();
+    expect(screen.getByLabelText("Character count")).toHaveTextContent("0 / 4000");
+  });
+
+  it("updates character count as user types", async () => {
     const user = userEvent.setup();
     render(<ChatInput onSend={() => {}} disabled={false} />);
 
     const textarea = screen.getByPlaceholderText("Type a message...");
     await user.type(textarea, "Hello");
 
-    expect(screen.getByText("5 / 4000")).toBeInTheDocument();
+    expect(screen.getByLabelText("Character count")).toHaveTextContent("5 / 4000");
   });
 
-  it("disables send button when over 4000 character limit", async () => {
-    render(<ChatInput onSend={() => {}} disabled={false} />);
+  it("disables send button when over 4000 characters", () => {
+    const onSend = mock(() => {});
+    render(<ChatInput onSend={onSend} disabled={false} />);
 
-    // Simulate a value over the limit by checking the component behavior
-    // We test the over-limit state by checking the counter displays correctly at 0
-    expect(screen.getByText("0 / 4000")).toBeInTheDocument();
+    const textarea = screen.getByPlaceholderText("Type a message...");
+    // Use fireEvent for large input to avoid userEvent timeout
+    fireEvent.change(textarea, { target: { value: "a".repeat(4001) } });
+
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+  });
+
+  it("clears character count after sending", async () => {
+    const onSend = mock(() => {});
+    const user = userEvent.setup();
+    render(<ChatInput onSend={onSend} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText("Type a message...");
+    await user.type(textarea, "Hello");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(screen.getByLabelText("Character count")).toHaveTextContent("0 / 4000");
   });
 });


### PR DESCRIPTION
## Summary

- Display live character count below the chat input, right-aligned, formatted as `X / 4000`
- Count text turns **amber** when characters exceed 3800 (warning threshold)
- Count text turns **red** and the send button is **disabled** when characters exceed 4000
- Uses existing Tailwind classes following the project's dark theme patterns

Closes #6

## Test plan
- [x] Type in the chat input and verify the counter shows correctly (e.g. `5 / 4000`)
- [x] Verify count text is muted/subtle in normal state
- [x] Verify count text turns amber after 3800 characters
- [x] Verify count text turns red and send button is disabled after 4000 characters
- [x] Verify send button re-enables after deleting characters to go back under the limit
- [x] Run `bun test` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)