### PR TITLE
fix: quote argument-hint YAML for Copilot CLI 1.0.65 compatibility

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git diff:*), Bash(git commit:*)
-argument-hint: [files...]
+argument-hint: "[files...]"
 description: Create atomic commit with conventional prefix
 ---
 

--- a/.claude/commands/create-command.md
+++ b/.claude/commands/create-command.md
@@ -199,7 +199,7 @@ Aggregate results before proceeding.
 ```markdown
 ---
 description: {What it does in one line}
-argument-hint: {If needed}
+argument-hint: "{If needed}"
 ---
 
 <objective>
@@ -227,7 +227,7 @@ argument-hint: {If needed}
 ```markdown
 ---
 description: {What it does}
-argument-hint: {Input description}
+argument-hint: "{Input description}"
 ---
 
 <objective>

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,6 +1,6 @@
 ---
 description: Create a pull request for current branch
-argument-hint: [base-branch]
+argument-hint: "[base-branch]"
 ---
 
 <objective>

--- a/.claude/commands/prd.md
+++ b/.claude/commands/prd.md
@@ -1,6 +1,6 @@
 ---
 description: Interactive PRD generator - problem-first, hypothesis-driven product spec
-argument-hint: [feature/product idea] (blank = start with questions)
+argument-hint: "[feature/product idea] (blank = start with questions)"
 ---
 
 # Product Requirements Document Generator

--- a/.claude/skills/build-with-agent-team/SKILL.md
+++ b/.claude/skills/build-with-agent-team/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: build-with-agent-team
 description: Build a project using Claude Code Agent Teams with tmux split panes. Takes a plan document path and optional team size. Use when you want multiple agents collaborating on a build.
-argument-hint: [plan-path] [num-agents]
+argument-hint: "[plan-path] [num-agents]"
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary

Several `.claude/` files have `argument-hint:` frontmatter values whose YAML parses as a **flow-sequence** or **flow-mapping** (or fails entirely), instead of the string that Copilot CLI 1.0.65 now strictly requires. This PR quotes the affected values.

## The YAML rule

In YAML, an unquoted scalar that begins with `[` or `{` starts a flow-collection, not a string:

- `argument-hint: [files...]` -> `list(['files...'])`
- `argument-hint: [X] [Y]` -> **invalid YAML** (two flow-sequences at one key)
- `argument-hint: [X] (extra)` -> **invalid YAML**
- `argument-hint: "[X] [Y]"` -> `"[X] [Y]"` (string, correct)

Values that begin with `<` or a letter (plain scalars) are already strings, so they were left unchanged.

## Verification

Before the fix, several frontmatter blocks failed `yaml.safe_load` outright (e.g. `prd.md`, and the same class as `SKILL.md`'s two-sequences case). After the fix, all four affected frontmatter values parse as strings.

## Files changed

| File | Before | After |
|---|---|---|
| `.claude/skills/build-with-agent-team/SKILL.md` | `[plan-path] [num-agents]` | `"[plan-path] [num-agents]"` |
| `.claude/commands/commit.md` | `[files...]` | `"[files...]"` |
| `.claude/commands/create-pr.md` | `[base-branch]` | `"[base-branch]"` |
| `.claude/commands/prd.md` | `[feature/product idea] (blank = start with questions)` | quoted |
| `.claude/commands/create-command.md` | template examples with `{If needed}` / `{Input description}` | quoted (so newly generated commands are compliant) |

Untouched (already valid): `implement.md`, `plan.md`, `rca.md`, `review-pr.md`, and the `<input>` example in `create-command.md`.

## References

- Underlying Claude Code (latent) issue: anthropics/claude-code#22161

## Test plan

- [x] `yaml.safe_load` on each fixed frontmatter returns a `str`
- [x] Confirmed `prd.md` pre-fix was unparseable YAML; post-fix parses cleanly
- [ ] Load a fixed command / skill under Copilot CLI 1.0.65 and confirm no `argument-hint` type error
- [ ] Existing Claude Code behavior unchanged (argument-hint continues to render as literal string in the UI)
